### PR TITLE
Add profile endpoint and basic UI pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ frontend/      React application
 ## API Endpoints
 - `POST /api/auth/register` - register new user
 - `POST /api/auth/login` - authenticate user
+- `GET /api/users/me` - current authenticated user profile
 - `GET /api/movies/search` - search movies by title
 - `GET /api/movies/favorites` - list favorite movie IDs
 - `POST /api/movies/favorites` - add favorite movie ID

--- a/backend/app.js
+++ b/backend/app.js
@@ -13,6 +13,7 @@ app.use(express.json());
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/movies', require('./routes/movies'));
 app.use('/api/reviews', require('./routes/reviews'));
+app.use('/api/users', require('./routes/users'));
 
 module.exports = app;
 

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,0 +1,10 @@
+const User = require('../models/User');
+
+exports.getMe = async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select('-password');
+    res.json(user);
+  } catch (err) {
+    res.status(500).send('Server error');
+  }
+};

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const { getMe } = require('../controllers/userController');
+
+router.get('/me', auth, getMe);
+
+module.exports = router;

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -81,3 +81,24 @@ describe('Movie operations', () => {
     expect(res.body).not.toContain(movieId);
   });
 });
+
+describe('User routes', () => {
+  test('returns current user profile', async () => {
+    await request(app)
+      .post('/api/auth/register')
+      .send({ name: 'Prof', email: 'prof@example.com', password: 'pass' });
+
+    const login = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'prof@example.com', password: 'pass' });
+    const token = login.body.token;
+
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.email).toBe('prof@example.com');
+    expect(res.body.password).toBeUndefined();
+  });
+});

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -16,6 +16,11 @@ curl -X POST http://localhost:5000/api/auth/login \
 
 Save the returned token for the following requests:
 
+## Current User Profile
+```bash
+curl -H "Authorization: Bearer <TOKEN>" http://localhost:5000/api/users/me
+```
+
 ## Search Movies
 ```bash
 curl "http://localhost:5000/api/movies/search?title=inception"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,11 +6,15 @@ import Home from './pages/Home';
 import Watchlist from './pages/Watchlist';
 import Favorites from './pages/Favorites';
 import SubmitReview from './pages/SubmitReview';
+import Profile from './pages/Profile';
+import MovieDetails from './pages/MovieDetails';
+import NavBar from './components/NavBar';
 import PrivateRoute from './components/PrivateRoute';
 
 function App() {
   return (
     <Router>
+      <NavBar />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
@@ -39,6 +43,15 @@ function App() {
             </PrivateRoute>
           }
         />
+        <Route
+          path="/profile"
+          element={
+            <PrivateRoute>
+              <Profile />
+            </PrivateRoute>
+          }
+        />
+        <Route path="/movie/:id" element={<MovieDetails />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const NavBar = () => {
+  const { token, logout } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <nav className="navbar">
+      <h1 className="logo">MovieApp</h1>
+      <div className="nav-links">
+        <Link to="/">Home</Link>
+        {token && <Link to="/watchlist">Watchlist</Link>}
+        {token && <Link to="/favorites">Favorites</Link>}
+        {token && <Link to="/profile">Profile</Link>}
+        {token && <Link to="/submit-review">Review</Link>}
+        {!token && <Link to="/login">Login</Link>}
+        {!token && <Link to="/register">Register</Link>}
+        {token && (
+          <button onClick={handleLogout} className="link-button">
+            Logout
+          </button>
+        )}
+      </div>
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/frontend/src/pages/Favorites.js
+++ b/frontend/src/pages/Favorites.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 
 const Favorites = () => {
@@ -54,12 +55,14 @@ const Favorites = () => {
       <div className="movie-grid">
         {movies.map((movie) => (
           <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
-            {movie.poster_path && (
-              <img
-                src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
-                alt={movie.title}
-              />
-            )}
+            <Link to={`/movie/${movie.id}`}>
+              {movie.poster_path && (
+                <img
+                  src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                  alt={movie.title}
+                />
+              )}
+            </Link>
             <h3>{movie.title}</h3>
             <button onClick={() => removeMovie(movie.id)}>Remove</button>
           </div>

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,11 +1,28 @@
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import axios from 'axios';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 
 const Home = () => {
   const [query, setQuery] = useState('');
   const [movies, setMovies] = useState([]);
   const { token } = useContext(AuthContext);
+
+  useEffect(() => {
+    const fetchTrending = async () => {
+      try {
+        const res = await axios.get(
+          'https://api.themoviedb.org/3/trending/movie/week',
+          { params: { api_key: process.env.REACT_APP_TMDB_KEY } }
+        );
+        setMovies(res.data.results || []);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    fetchTrending();
+  }, []);
 
   const searchMovies = async (e) => {
     e.preventDefault();
@@ -69,15 +86,18 @@ const Home = () => {
         <button type="submit">Search</button>
       </form>
 
+      <h3>Trending Movies</h3>
       <div className="movie-grid">
         {movies.map((movie) => (
           <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
-            {movie.poster_path && (
-              <img
-                src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
-                alt={movie.title}
-              />
-            )}
+            <Link to={`/movie/${movie.id}`}>
+              {movie.poster_path && (
+                <img
+                  src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                  alt={movie.title}
+                />
+              )}
+            </Link>
             <h3>{movie.title}</h3>
             <button onClick={() => addWatchlist(movie.id)}>Add to Watchlist</button>
             <button onClick={() => addFavorite(movie.id)}>Add to Favorite</button>

--- a/frontend/src/pages/MovieDetails.js
+++ b/frontend/src/pages/MovieDetails.js
@@ -1,0 +1,83 @@
+import React, { useEffect, useState, useContext } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+const MovieDetails = () => {
+  const { id } = useParams();
+  const [movie, setMovie] = useState(null);
+  const [reviews, setReviews] = useState([]);
+  const [text, setText] = useState('');
+  const { token } = useContext(AuthContext);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const details = await axios.get(
+          `https://api.themoviedb.org/3/movie/${id}`,
+          { params: { api_key: process.env.REACT_APP_TMDB_KEY } }
+        );
+        setMovie(details.data);
+        const { data } = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/reviews/movie/${id}`
+        );
+        setReviews(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchData();
+  }, [id]);
+
+  const submitReview = async () => {
+    if (!text.trim()) return;
+    try {
+      const res = await axios.post(
+        `${process.env.REACT_APP_API_URL}/api/reviews`,
+        { movieId: id, text },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setReviews([...reviews, res.data]);
+      setText('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (!movie) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>{movie.title}</h2>
+      {movie.poster_path && (
+        <img
+          src={`https://image.tmdb.org/t/p/w300${movie.poster_path}`}
+          alt={movie.title}
+        />
+      )}
+      <p>{movie.overview}</p>
+
+      <h3>Reviews</h3>
+      <ul>
+        {reviews.map((r) => (
+          <li key={r._id}>
+            {r.rating && <strong>{r.rating}/10 </strong>}
+            {r.text}
+          </li>
+        ))}
+      </ul>
+      {token && (
+        <div>
+          <textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Write a review"
+          />
+          <button onClick={submitReview}>Submit</button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MovieDetails;

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState, useContext } from 'react';
+import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
+import { Link } from 'react-router-dom';
+
+const Profile = () => {
+  const { token } = useContext(AuthContext);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.REACT_APP_API_URL}/api/users/me`,
+          { headers: { Authorization: `Bearer ${token}` } }
+        );
+        setUser(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchUser();
+  }, [token]);
+
+  if (!user) return <p>Loading...</p>;
+
+  return (
+    <div>
+      <h2>{user.name}'s Profile</h2>
+      <p>Email: {user.email}</p>
+      <h3>Your Watchlist</h3>
+      <ul>
+        {user.watchlist.map((id) => (
+          <li key={id}>
+            <Link to={`/movie/${id}`}>{id}</Link>
+          </li>
+        ))}
+      </ul>
+      <h3>Your Favorites</h3>
+      <ul>
+        {user.favorites.map((id) => (
+          <li key={id}>
+            <Link to={`/movie/${id}`}>{id}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Profile;

--- a/frontend/src/pages/Watchlist.js
+++ b/frontend/src/pages/Watchlist.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext } from 'react';
 import axios from 'axios';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 
 const Watchlist = () => {
@@ -54,12 +55,14 @@ const Watchlist = () => {
       <div className="movie-grid">
         {movies.map((movie) => (
           <div key={movie.id} className="movie-card" style={{ marginBottom: '1rem' }}>
-            {movie.poster_path && (
-              <img
-                src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
-                alt={movie.title}
-              />
-            )}
+            <Link to={`/movie/${movie.id}`}>
+              {movie.poster_path && (
+                <img
+                  src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`}
+                  alt={movie.title}
+                />
+              )}
+            </Link>
             <h3>{movie.title}</h3>
             <button onClick={() => removeMovie(movie.id)}>Remove</button>
           </div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,4 +1,47 @@
 body {
   margin: 0;
   font-family: Arial, sans-serif;
+  background-color: #141414;
+  color: #fff;
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background-color: #1f1f1f;
+}
+
+.nav-links a,
+.link-button {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.movie-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
+}
+
+.movie-card {
+  background-color: #222;
+  padding: 0.5rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.movie-card img {
+  width: 100%;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- create new `/api/users/me` endpoint
- build navigation bar and profile page
- show movie details with reviews
- link movie cards to details pages
- document new endpoint in README and test cases

## Testing
- `npm test` *(fails: process.exit called due to MongoDB download blocked)*
- `npm test -- -w=1` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e1b15479883339cefc491eb1f4637