### PR TITLE
Add environment sample docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This is a full-stack movie recommendation application built with the MERN stack.
    cp server/.env.example server/.env
    cp client/.env.example client/.env
    ```
+   The samples define the following variables:
+   - `MONGO_URI` – MongoDB connection string
+   - `JWT_SECRET` – secret for signing JWT tokens
+   - `TMDB_API_KEY` – your TMDB API key
+   - `PORT` – Express server port
+   - `VITE_API_URL` – URL of the backend API for the React app
 3. Start the development servers in separate terminals:
    ```bash
    # Server on port 5000

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -24,6 +24,12 @@ This guide covers getting the Movie Recommendation app running on Android using 
    cp server/.env.example server/.env
    cp client/.env.example client/.env
    ```
+   These files contain placeholders for:
+   - `MONGO_URI`
+   - `JWT_SECRET`
+   - `TMDB_API_KEY`
+   - `PORT`
+   - `VITE_API_URL`
 6. Start the backend and frontend in separate Termux sessions:
    ```bash
    npm --prefix server run dev
@@ -48,6 +54,7 @@ This guide covers getting the Movie Recommendation app running on Android using 
    copy server\.env.example server\.env
    copy client\.env.example client\.env
    ```
+   These files include variables named `MONGO_URI`, `JWT_SECRET`, `TMDB_API_KEY`, `PORT` and `VITE_API_URL`.
 5. In two terminals start the servers:
    ```bash
    npm --prefix server run dev


### PR DESCRIPTION
## Summary
- document the variables defined in the `.env.example` files

## Testing
- `npm --prefix client run build`
- `npm --prefix server run dev` *(fails: MongoDB connection string missing)*

------
https://chatgpt.com/codex/tasks/task_e_685160f7253c8333adc88d01979ebdb5