### PR TITLE
Implement multiple watchlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a full-stack movie recommendation application built with the MERN stack.
 ## Features
 - JWT based authentication with registration and login
 - Browse trending movies and search by title
-- Save movies to personal watchlists
+- Save movies to personal watchlists (multiple lists supported)
 - Rate and review movies
 - Responsive mobile‑first UI built with React and Tailwind CSS
 
@@ -35,9 +35,12 @@ This is a full-stack movie recommendation application built with the MERN stack.
 - `GET /movies/search?q=query` – search movies via TMDB
 - `GET /movies/trending` – trending movies
 - `GET /users/profile` – get current user profile (requires auth)
-- `POST /watchlist/add` – add movie to watchlist (requires auth)
-- `GET /watchlist` – list saved movies (requires auth)
-- `DELETE /watchlist/:movieId` – remove movie from watchlist
+- `POST /watchlist` – create a new watchlist (requires auth)
+- `PUT /watchlist/:id` – rename/update a watchlist (requires auth)
+- `DELETE /watchlist/:id` – delete a watchlist (requires auth)
+- `POST /watchlist/:id/add` – add movie to a watchlist (requires auth)
+- `GET /watchlist` – list all watchlists with movies (requires auth)
+- `DELETE /watchlist/:id/movies/:movieId` – remove movie from a watchlist
 - `POST /reviews/:movieId` – create a movie review (requires auth)
 - `GET /reviews/:movieId` – list reviews for a movie
 - `GET /movies/:id` – movie details

--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -7,9 +7,10 @@ const MovieCard = ({ movie }) => {
 
   const add = async (e) => {
     e.preventDefault();
-    if (!user) return;
+    if (!user || !user.watchlists || user.watchlists.length === 0) return;
     const token = localStorage.getItem('token');
-    await axios.post('/watchlist/add', { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path }, { headers: { Authorization: `Bearer ${token}` } });
+    const listId = user.watchlists[0]._id;
+    await axios.post(`/watchlist/${listId}/add`, { tmdbId: movie.id, title: movie.title, posterPath: movie.poster_path }, { headers: { Authorization: `Bearer ${token}` } });
   };
 
   return (

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -32,7 +32,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout }}>
+    <AuthContext.Provider value={{ user, login, register, logout, setUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/MovieDetail.jsx
+++ b/client/src/pages/MovieDetail.jsx
@@ -20,8 +20,9 @@ const MovieDetail = () => {
 
   const addToWatchlist = async () => {
     const token = localStorage.getItem('token');
-    if (!token) return;
-    await axios.post('/watchlist/add', { tmdbId: id, title: movie.title, posterPath: movie.poster_path }, { headers: { Authorization: `Bearer ${token}` } });
+    if (!token || !user || !user.watchlists || user.watchlists.length === 0) return;
+    const listId = user.watchlists[0]._id;
+    await axios.post(`/watchlist/${listId}/add`, { tmdbId: id, title: movie.title, posterPath: movie.poster_path }, { headers: { Authorization: `Bearer ${token}` } });
   };
 
   const submitReview = async (e) => {

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -15,10 +15,12 @@ const Profile = () => {
         <button onClick={logout} className="bg-red-500 px-4 py-1">Logout</button>
       </div>
       <div>
-        <h3 className="text-lg mb-2">Watchlist</h3>
-        {user.watchlist.length === 0 && <p>No movies saved.</p>}
+        <h3 className="text-lg mb-2">Watchlists</h3>
+        {user.watchlists.length === 0 && <p>No watchlists.</p>}
         <ul className="list-disc ml-6">
-          {user.watchlist.map(m => <li key={m.tmdbId}>{m.title}</li>)}
+          {user.watchlists.map(l => (
+            <li key={l._id}>{l.name} ({l.movies.length})</li>
+          ))}
         </ul>
       </div>
       <div>

--- a/client/src/pages/Watchlist.jsx
+++ b/client/src/pages/Watchlist.jsx
@@ -4,37 +4,78 @@ import MovieCard from '../components/MovieCard.jsx';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 const Watchlist = () => {
-  const { user } = useContext(AuthContext);
-  const [movies, setMovies] = useState([]);
+  const { user, setUser } = useContext(AuthContext);
+  const [lists, setLists] = useState([]);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
 
   useEffect(() => {
     if (!user) return;
     const token = localStorage.getItem('token');
     axios.get('/watchlist', { headers: { Authorization: `Bearer ${token}` } })
-      .then(res => setMovies(res.data))
-      .catch(() => setMovies([]));
+      .then(res => setLists(res.data))
+      .catch(() => setLists([]));
   }, [user]);
 
-  const remove = async (tmdbId) => {
+  const create = async (e) => {
+    e.preventDefault();
     const token = localStorage.getItem('token');
-    const res = await axios.delete(`/watchlist/${tmdbId}`, { headers: { Authorization: `Bearer ${token}` } });
-    setMovies(res.data);
+    const res = await axios.post('/watchlist', { name, description }, { headers: { Authorization: `Bearer ${token}` } });
+    setLists([...lists, res.data]);
+    setUser({ ...user, watchlists: [...(user.watchlists || []), res.data] });
+    setName('');
+    setDescription('');
+  };
+
+
+  const removeMovie = async (listId, movieId) => {
+    const token = localStorage.getItem('token');
+    const res = await axios.delete(`/watchlist/${listId}/movies/${movieId}`, { headers: { Authorization: `Bearer ${token}` } });
+    setLists(lists.map(l => l._id === listId ? { ...l, movies: res.data } : l));
+    setUser({
+      ...user,
+      watchlists: user.watchlists.map(l => l._id === listId ? { ...l, movies: res.data } : l)
+    });
+  };
+
+  const delList = async (id) => {
+    const token = localStorage.getItem('token');
+    await axios.delete(`/watchlist/${id}`, { headers: { Authorization: `Bearer ${token}` } });
+    setLists(lists.filter(l => l._id !== id));
+    setUser({ ...user, watchlists: user.watchlists.filter(l => l._id !== id) });
   };
 
   if (!user) return <p className="p-4">Please login</p>;
 
   return (
     <div className="p-4">
-      <h2 className="text-xl mb-4">My Watchlist</h2>
-      {movies.length === 0 && <p>No movies saved.</p>}
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-        {movies.map(m => (
-          <div key={m.tmdbId} className="relative">
-            <MovieCard movie={{ id: m.tmdbId, title: m.title, poster_path: m.posterPath }} />
-            <button onClick={() => remove(m.tmdbId)} className="absolute top-2 right-2 bg-red-500 px-2 text-sm">Remove</button>
+      <h2 className="text-xl mb-4">My Watchlists</h2>
+
+      <form onSubmit={create} className="mb-6 space-x-2">
+        <input className="p-1 text-black" value={name} onChange={e => setName(e.target.value)} placeholder="New list name" />
+        <input className="p-1 text-black" value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" />
+        <button className="bg-blue-500 px-2" type="submit">Create</button>
+      </form>
+
+      {lists.length === 0 && <p>No watchlists yet.</p>}
+      {lists.map(list => (
+        <div key={list._id} className="mb-8">
+          <div className="flex items-center mb-2 space-x-2">
+            <h3 className="text-lg">{list.name}</h3>
+            <button onClick={() => delList(list._id)} className="text-sm bg-red-500 px-2">Delete</button>
           </div>
-        ))}
-      </div>
+          {list.description && <p className="mb-2 text-sm text-gray-300">{list.description}</p>}
+          {list.movies.length === 0 && <p>No movies.</p>}
+          <div className="overflow-x-auto flex gap-4 pb-2">
+            {list.movies.map(m => (
+              <div key={m.tmdbId} className="relative">
+                <MovieCard movie={{ id: m.tmdbId, title: m.title, poster_path: m.posterPath }} />
+                <button onClick={() => removeMovie(list._id, m.tmdbId)} className="absolute top-2 right-2 bg-red-500 px-2 text-sm">Remove</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
     </div>
   );
 };

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -5,9 +5,9 @@ import Review from '../models/Review.js';
 export const getProfile = async (req, res) => {
   try {
     const user = await User.findById(req.user).select('-password');
-    const watchlist = await Watchlist.findOne({ user: req.user });
+    const watchlists = await Watchlist.find({ user: req.user });
     const reviews = await Review.find({ userId: req.user });
-    res.json({ user, watchlist: watchlist ? watchlist.movies : [], reviews });
+    res.json({ user, watchlists, reviews });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/server/src/models/Watchlist.js
+++ b/server/src/models/Watchlist.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 const watchlistSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   name: { type: String, required: true },
+  description: String,
   movies: [{
     tmdbId: String,
     title: String,

--- a/server/src/routes/watchlist.js
+++ b/server/src/routes/watchlist.js
@@ -1,9 +1,19 @@
 import express from 'express';
-import { addMovie, deleteMovie, getWatchlist } from '../controllers/watchlistController.js';
+import {
+  addMovie,
+  deleteMovie,
+  getWatchlist,
+  createWatchlist,
+  updateWatchlist,
+  deleteWatchlist,
+} from '../controllers/watchlistController.js';
 import { protect } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/', protect, getWatchlist);
-router.post('/add', protect, addMovie);
-router.delete('/:movieId', protect, deleteMovie);
+router.post('/', protect, createWatchlist);
+router.put('/:id', protect, updateWatchlist);
+router.delete('/:id', protect, deleteWatchlist);
+router.post('/:id/add', protect, addMovie);
+router.delete('/:id/movies/:movieId', protect, deleteMovie);
 export default router;


### PR DESCRIPTION
## Summary
- allow several watchlists per user and store optional descriptions
- expose CRUD routes for watchlists and movie management
- update user profile and watchlist pages to handle multiple lists
- use first watchlist when adding movies from other pages
- document new endpoints in README

## Testing
- `npm run build` in `client`
- `npm start` in `server` *(fails: MongoDB URI undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68516279ee6483339c830f13c08bc724