### PR TITLE
Add advanced recommendation service

### DIFF
--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -7,6 +7,7 @@ import { AuthContext } from '../context/AuthContext.jsx';
 const Home = () => {
   const [movies, setMovies] = useState([]);
   const [recommended, setRecommended] = useState([]);
+  const [advanced, setAdvanced] = useState([]);
   const [query, setQuery] = useState('');
   const [genre, setGenre] = useState('');
   const [year, setYear] = useState('');
@@ -20,6 +21,7 @@ const Home = () => {
   useEffect(() => {
     if (!user) {
       setRecommended([]);
+      setAdvanced([]);
       return;
     }
     const token = localStorage.getItem('token');
@@ -29,6 +31,12 @@ const Home = () => {
       })
       .then(res => setRecommended(res.data.results))
       .catch(() => setRecommended([]));
+    axios
+      .get('/movies/recommendations/advanced', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then(res => setAdvanced(res.data.results))
+      .catch(() => setAdvanced([]));
   }, [user]);
 
   const search = async (e) => {
@@ -68,6 +76,13 @@ const Home = () => {
       {user && recommended.length > 0 && (
         <Slider title="Recommended for You">
           {recommended.map(m => (
+            <MovieCard key={m.id} movie={m} />
+          ))}
+        </Slider>
+      )}
+      {user && advanced.length > 0 && (
+        <Slider title="Top Picks">
+          {advanced.map(m => (
             <MovieCard key={m.id} movie={m} />
           ))}
         </Slider>

--- a/server/src/models/Recommendation.js
+++ b/server/src/models/Recommendation.js
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const recommendationSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  movieId: { type: String, required: true },
+  title: String,
+  posterPath: String,
+  score: Number,
+}, { timestamps: true });
+
+export default mongoose.model('Recommendation', recommendationSchema);

--- a/server/src/routes/movies.js
+++ b/server/src/routes/movies.js
@@ -1,11 +1,12 @@
 import express from 'express';
-import { searchMovies, trendingMovies, movieDetails, movieVideos, recommendedMovies } from '../controllers/movieController.js';
+import { searchMovies, trendingMovies, movieDetails, movieVideos, recommendedMovies, advancedRecommendations } from '../controllers/movieController.js';
 import { protect } from '../middleware/auth.js';
 
 const router = express.Router();
 router.get('/search', searchMovies);
 router.get('/trending', trendingMovies);
 router.get('/recommendations', protect, recommendedMovies);
+router.get('/recommendations/advanced', protect, advancedRecommendations);
 router.get('/:id/videos', movieVideos);
 router.get('/:id', movieDetails);
 export default router;


### PR DESCRIPTION
## Summary
- create `Recommendation` mongoose model
- compute advanced recommendations using user review genres
- expose advanced recommendations API route
- show advanced recommendations slider on home page

## Testing
- `npm --prefix server test` *(fails: Missing script)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a153ea748333b0a0dbdc4d245cab