### PR TITLE
Improve hero and pagination

### DIFF
--- a/client/src/components/Hero.jsx
+++ b/client/src/components/Hero.jsx
@@ -5,16 +5,23 @@ const Hero = () => {
   const [movies, setMovies] = useState([]);
 
   useEffect(() => {
-    axios.get('/movies/trending').then(res => setMovies(res.data.results.slice(0,3)));
+    axios.get('/movies/trending?page=1').then(res => setMovies(res.data.results.slice(0,10)));
   }, []);
 
   return (
-    <div className="text-center py-8 overflow-hidden">
-      <h1 className="text-3xl font-semibold mb-4">Find Your Next Favorite Movie</h1>
-      <div className="flex gap-4 justify-center animate-[scroll_20s_linear_infinite]">
-        {movies.map(m => (
-          <img key={m.id} src={`https://image.tmdb.org/t/p/w200${m.poster_path}`} alt={m.title} className="w-32 rounded" />
-        ))}
+    <div className="overflow-hidden py-8">
+      <h1 className="text-3xl font-semibold mb-4 text-center">Find Your Next Favorite Movie</h1>
+      <div className="banner-container">
+        <div className="scroll-banner">
+          {movies.concat(movies).map((m, idx) => (
+            <img
+              key={idx}
+              src={`https://image.tmdb.org/t/p/w500${m.poster_path}`}
+              alt={m.title}
+              className="h-64 w-auto object-cover flex-shrink-0"
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/MovieCard.jsx
+++ b/client/src/components/MovieCard.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useContext } from 'react';
 import axios from 'axios';
+import { motion } from 'framer-motion';
 import { AuthContext } from '../context/AuthContext.jsx';
 
 const MovieCard = ({ movie }) => {
@@ -15,11 +16,13 @@ const MovieCard = ({ movie }) => {
   };
 
   return (
-    <Link to={`/movie/${movie.id}`} className="bg-surface p-2 rounded relative block transition duration-300 hover:scale-105 hover:shadow-lg">
-      <img src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`} alt={movie.title} className="mx-auto" />
-      <h3 className="mt-2 text-center text-sm">{movie.title}</h3>
-      {user && <button onClick={add} className="absolute top-1 right-1 bg-blue-500 text-xs px-1">Add</button>}
-    </Link>
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.5 }}>
+      <Link to={`/movie/${movie.id}`} className="bg-surface p-2 rounded relative block transition duration-300 hover:scale-105 hover:shadow-lg">
+        <img src={`https://image.tmdb.org/t/p/w200${movie.poster_path}`} alt={movie.title} className="mx-auto" />
+        <h3 className="mt-2 text-center text-sm">{movie.title}</h3>
+        {user && <button onClick={add} className="absolute top-1 right-1 bg-blue-500 text-xs px-1">Add</button>}
+      </Link>
+    </motion.div>
   );
 };
 export default MovieCard;

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -9,7 +9,7 @@ const slideDown = keyframes`
 `;
 
 const Bar = styled.nav`
-  background: linear-gradient(to right, rgba(192,38,211,0.9), rgba(6,182,212,0.9));
+  background: linear-gradient(to right, #9b5de5, #52057b);
   padding: 1rem;
   display: flex;
   justify-content: space-between;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -4,3 +4,18 @@
 body {
   @apply font-sans bg-background text-white;
 }
+
+@keyframes scrollBanner {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+.banner-container {
+  overflow: hidden;
+}
+
+.scroll-banner {
+  display: flex;
+  width: max-content;
+  animation: scrollBanner 30s linear infinite;
+}

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -13,11 +13,12 @@ const Home = () => {
   const [genre, setGenre] = useState('');
   const [year, setYear] = useState('');
   const [sortBy, setSortBy] = useState('');
+  const [page, setPage] = useState(1);
   const { user } = useContext(AuthContext);
 
   useEffect(() => {
-    axios.get('/movies/trending').then(res => setMovies(res.data.results));
-  }, []);
+    axios.get(`/movies/trending?page=${page}`).then(res => setMovies(res.data.results));
+  }, [page]);
 
   useEffect(() => {
     if (!user) {
@@ -91,6 +92,21 @@ const Home = () => {
       )}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {movies.map(m => <MovieCard key={m.id} movie={m} />)}
+      </div>
+      <div className="mt-4 flex justify-center items-center gap-1 flex-wrap">
+        <button onClick={() => setPage(p => Math.max(1, p - 1))}>&lt;</button>
+        <div className="overflow-x-auto flex gap-1 max-w-full">
+          {Array.from({ length: 100 }, (_, i) => i + 1).map(num => (
+            <button
+              key={num}
+              onClick={() => setPage(num)}
+              className={num === page ? 'font-bold underline' : ''}
+            >
+              {num}
+            </button>
+          ))}
+        </div>
+        <button onClick={() => setPage(p => Math.min(100, p + 1))}>&gt;</button>
       </div>
     </div>
   );

--- a/server/src/controllers/movieController.js
+++ b/server/src/controllers/movieController.js
@@ -24,10 +24,15 @@ export const searchMovies = async (req, res) => {
 
 export const trendingMovies = async (req, res) => {
   try {
-    const query = new URLSearchParams({ api_key: process.env.TMDB_API_KEY });
-    const response = await fetch(`${TMDB_BASE}/trending/movie/week?${query}`);
-    const data = await response.json();
-    res.json(data);
+    const page = parseInt(req.query.page) || 1;
+    const query1 = new URLSearchParams({ api_key: process.env.TMDB_API_KEY, page });
+    const resp1 = await fetch(`${TMDB_BASE}/trending/movie/week?${query1}`);
+    const data1 = await resp1.json();
+    const query2 = new URLSearchParams({ api_key: process.env.TMDB_API_KEY, page: page + 1 });
+    const resp2 = await fetch(`${TMDB_BASE}/trending/movie/week?${query2}`);
+    const data2 = await resp2.json();
+    const results = [...(data1.results || []), ...(data2.results || [])].slice(0, 30);
+    res.json({ results });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/server/src/controllers/reviewController.js
+++ b/server/src/controllers/reviewController.js
@@ -1,4 +1,7 @@
 import Review from '../models/Review.js';
+import fetch from 'node-fetch';
+
+const TMDB_BASE = 'https://api.themoviedb.org/3';
 
 // Create a new review for a movie
 export const createReview = async (req, res) => {
@@ -18,8 +21,10 @@ export const createReview = async (req, res) => {
 // Get all reviews for a specific movie
 export const getReviews = async (req, res) => {
   try {
-    const reviews = await Review.find({ movieId: req.params.movieId }).populate('userId', 'name');
-    res.json(reviews);
+    const query = new URLSearchParams({ api_key: process.env.TMDB_API_KEY });
+    const response = await fetch(`${TMDB_BASE}/movie/${req.params.movieId}/reviews?${query}`);
+    const data = await response.json();
+    res.json(data.results || []);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }


### PR DESCRIPTION
## Summary
- add auto-scrolling hero with large posters
- update navbar gradient to deep purple
- fade in movie cards on entry
- add pagination with 100-page navigation
- fetch TMDB reviews server side
- return 30 movies per page from backend trending API

## Testing
- `npm --prefix client run build`
- `node -e "console.log('node works')"`


------
https://chatgpt.com/codex/tasks/task_e_6855a9d416b08333944892a8d0daa879