### PR TITLE
Fix movie details page base URL

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,4 +1,4 @@
 import axios from "axios";
 export const BASE_URL =
-  import.meta.env.VITE_API_URL || "https://threemtt-capstone.onrender.com";
+  (import.meta.env.VITE_API_URL || "https://threemtt-capstone.onrender.com").replace(/\/+$/, '') + '/';
 export const api = axios.create({ baseURL: BASE_URL });


### PR DESCRIPTION
## Summary
- ensure API base URL ends with a single slash

## Testing
- `node -e "const axios=require('axios'); const instance=axios.create({baseURL:'http://localhost:5000'}); console.log(instance.getUri({url:'movies/123'}))"`

------
https://chatgpt.com/codex/tasks/task_e_685643235c1c8333a49360e3f6151944