### PR TITLE
Fix search genres and sync auth forms

### DIFF
--- a/client/src/components/AuthForm.jsx
+++ b/client/src/components/AuthForm.jsx
@@ -1,4 +1,4 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext.jsx';
 
@@ -18,6 +18,10 @@ export default function AuthForm({ mode = 'login' }) {
     setIsLogin(!isLogin);
     setMessage("");
   };
+
+  useEffect(() => {
+    setIsLogin(mode === 'login');
+  }, [mode]);
 
   const handleChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -84,7 +88,7 @@ export default function AuthForm({ mode = 'login' }) {
 
           <button
             type="submit"
-            className="w-full bg-red-600 hover:bg-red-700 p-3 rounded-3xl font-semibold transition cursor-pointer"
+            className="w-full bg-purple-600 hover:bg-purple-700 p-3 rounded-3xl font-semibold transition cursor-pointer"
           >
             {isLogin ? "Login" : "Register"}
           </button>

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -6,6 +6,12 @@ import HeroVideo from '../components/HeroVideo.jsx';
 import useInfiniteScroll from '../hooks/useInfiniteScroll.js';
 import { AuthContext } from '../context/AuthContext.jsx';
 
+const GENRE_IDS = {
+  Action: 28,
+  Romance: 10749,
+  Comedy: 35,
+};
+
 const Home = () => {
   const [movies, setMovies] = useState([]);
   const [page, setPage] = useState(1);
@@ -59,7 +65,10 @@ const Home = () => {
       const res = await api.get('movies/search', {
         params: {
           q,
-          genre: searchFilters.genres.join(','),
+          genre: searchFilters.genres
+            .map((name) => GENRE_IDS[name])
+            .filter(Boolean)
+            .join(','),
           year: searchFilters.year,
           page: pageNum,
         },

--- a/server/src/controllers/movieController.js
+++ b/server/src/controllers/movieController.js
@@ -7,12 +7,13 @@ const TMDB_BASE = 'https://api.themoviedb.org/3';
 
 export const searchMovies = async (req, res) => {
   try {
-    const { q, year, genre, sortBy } = req.query;
+    const { q, year, genre, sortBy, page = 1 } = req.query;
     const params = new URLSearchParams({ api_key: process.env.TMDB_API_KEY });
     if (q) params.append('query', q);
     if (year) params.append('year', year);
     if (genre) params.append('with_genres', genre);
     if (sortBy) params.append('sort_by', sortBy);
+    params.append('page', page);
 
     let endpoint = `${TMDB_BASE}/search/movie?${params}`;
     // If no text query is provided, fall back to discover endpoint so


### PR DESCRIPTION
## Summary
- sync AuthForm mode with URL changes and use purple submit button
- accept `page` param in searchMovies controller
- map genre names to TMDB IDs for search

## Testing
- `npm --prefix client run build`
- `npm --prefix server run start` *(fails: MongoDB connection string missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859239053788333809163e4c4cd9d02