### PR TITLE
Add avatar picker and responsive profile view

### DIFF
--- a/client/src/components/AvatarPicker.jsx
+++ b/client/src/components/AvatarPicker.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import Modal from './common/Modal.jsx';
+
+const options = ['avatar1.png', 'avatar2.png', 'avatar3.png'];
+
+const AvatarPicker = ({ value, onChange }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="text-center">
+      <img
+        src={`/avatars/${value}`}
+        alt="Avatar"
+        className="w-24 h-24 rounded-full object-cover mx-auto"
+      />
+      <button
+        type="button"
+        className="text-sm text-blue-400 underline mt-2"
+        onClick={() => setOpen(true)}
+      >
+        Change
+      </button>
+      <Modal open={open} onClose={() => setOpen(false)}>
+        <div className="grid grid-cols-3 gap-2">
+          {options.map((opt) => (
+            <img
+              key={opt}
+              src={`/avatars/${opt}`}
+              alt={opt}
+              onClick={() => {
+                onChange(opt);
+                setOpen(false);
+              }}
+              className={`w-16 h-16 rounded-full cursor-pointer border ${
+                value === opt ? 'border-blue-500' : 'border-transparent'
+              }`}
+            />
+          ))}
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default AvatarPicker;

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -41,13 +41,13 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const updateProfile = async (name, email) => {
+  const updateProfile = async (name, email, avatar) => {
     try {
       const token = localStorage.getItem('token');
       if (!token) return;
       const res = await api.put(
         'users/profile',
-        { name, email },
+        { name, email, avatar },
         { headers: { Authorization: `Bearer ${token}` } }
       );
       setUser(res.data);

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,57 +1,92 @@
 import { useContext, useState, useEffect } from 'react';
 import { AuthContext } from '../context/AuthContext.jsx';
+import AvatarPicker from '../components/AvatarPicker.jsx';
 
 const Profile = () => {
   const { user, logout, updateProfile } = useContext(AuthContext);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
+  const [avatar, setAvatar] = useState('avatar1.png');
+  const [updating, setUpdating] = useState(false);
 
   useEffect(() => {
     if (user) {
       setName(user.user.name);
       setEmail(user.user.email);
+      setAvatar(user.user.avatar || 'avatar1.png');
     }
   }, [user]);
+
   if (!user) return <p className="p-4">Loading...</p>;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    await updateProfile(name, email);
+    setUpdating(true);
+    await updateProfile(name, email, avatar);
+    setUpdating(false);
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <div className="flex justify-between items-center">
-        <div>
-          <h2 className="text-xl mb-1">{user.user.name}</h2>
-          <p>{user.user.email}</p>
+    <div className="p-4 relative max-w-3xl mx-auto">
+      <button
+        onClick={logout}
+        className="bg-gradient-to-r from-purple-600 to-blue-500 text-white rounded-md px-4 py-2 mt-4 sm:absolute sm:right-4 sm:top-4"
+      >
+        Logout
+      </button>
+
+      <div className="bg-surface p-6 rounded-3xl shadow-lg text-white grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div className="space-y-4">
+          <AvatarPicker value={avatar} onChange={setAvatar} />
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="text-lg font-medium">Name</label>
+              <input
+                className="w-full p-2 text-black"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="text-lg font-medium">Email</label>
+              <input
+                className="w-full p-2 text-black"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={updating}
+              className="w-full py-2 rounded text-white"
+              style={{ backgroundColor: '#4f8bff', opacity: updating ? 0.5 : 1 }}
+            >
+              Update
+            </button>
+          </form>
         </div>
-        <button onClick={logout} className="bg-red-500 px-4 py-1">Logout</button>
-      </div>
-      <form onSubmit={handleSubmit} className="space-y-2 max-w-sm">
-        <input className="w-full p-2 text-black" value={name} onChange={e => setName(e.target.value)} />
-        <input className="w-full p-2 text-black" value={email} onChange={e => setEmail(e.target.value)} />
-        <button className="w-full bg-blue-500 py-2" type="submit">Update</button>
-      </form>
-      <div>
-        <h3 className="text-lg mb-2">My Lists</h3>
-        {user.watchlists.length === 0 && <p>No watchlists.</p>}
-        <ul className="list-disc ml-6">
-          {user.watchlists.map(l => (
-            <li key={l._id}>{l.name} ({l.movies.length})</li>
-          ))}
-        </ul>
-      </div>
-      <div>
-        <h3 className="text-lg mb-2">My Reviews</h3>
-        {user.reviews.length === 0 && <p>No reviews yet.</p>}
-        <ul className="space-y-2">
-          {user.reviews.map(r => (
-            <li key={r._id} className="border-b border-gray-700 pb-1">
-              {r.movieId}: {r.rating}/5 - {r.comment}
-            </li>
-          ))}
-        </ul>
+
+        <div>
+          <h3 className="text-2xl font-semibold mb-2">Lists</h3>
+          <ul className="list-disc ml-6 space-y-1 text-lg font-medium">
+            <li>Favourites ({user.favorites ? user.favorites.length : 0})</li>
+            <li>Watchlist ({user.watchlists.length})</li>
+          </ul>
+
+          <h3 className="text-2xl font-semibold mt-6 mb-2">Reviews</h3>
+          {user.reviews.length === 0 ? (
+            <p>No reviews yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {user.reviews.map((r) => (
+                <li key={r._id} className="border-b border-gray-700 pb-1">
+                  {r.movieId}: {r.rating}/5 - {r.comment}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/docs/avatars.md
+++ b/docs/avatars.md
@@ -1,0 +1,9 @@
+# Avatar Images
+
+The following placeholder images must be added manually to `client/public/avatars/`:
+
+- `avatar1.png`
+- `avatar2.png`
+- `avatar3.png`
+
+Each image should be a square PNG (about 96x96) representing a simple user avatar. They are referenced by the `AvatarPicker` component on the Profile page.

--- a/server/src/controllers/authController.js
+++ b/server/src/controllers/authController.js
@@ -22,7 +22,7 @@ export const login = async (req, res) => {
     if (!user) return res.status(400).json({ message: 'Invalid credentials' });
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(400).json({ message: 'Invalid credentials' });
-    const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    const token = jwt.sign({ id: user._id, avatar: user.avatar }, process.env.JWT_SECRET, { expiresIn: '7d' });
     res.json({ token });
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/server/src/controllers/userController.js
+++ b/server/src/controllers/userController.js
@@ -19,10 +19,11 @@ export const updateProfile = async (req, res) => {
     if (!user) return res.status(404).json({ message: 'User not found' });
     if (req.body.name) user.name = req.body.name;
     if (req.body.email) user.email = req.body.email;
+    if (req.body.avatar) user.avatar = req.body.avatar;
     await user.save();
     const watchlist = await Watchlist.findOne({ user: req.user });
     const reviews = await Review.find({ userId: req.user });
-    const cleanUser = { _id: user._id, name: user.name, email: user.email };
+    const cleanUser = { _id: user._id, name: user.name, email: user.email, avatar: user.avatar };
     res.json({ user: cleanUser, watchlist: watchlist ? watchlist.movies : [], reviews });
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -4,6 +4,7 @@ const userSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
+  avatar: { type: String, default: 'avatar1.png' },
   following: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
 }, { timestamps: true });
 


### PR DESCRIPTION
## Summary
- add AvatarPicker component for choosing profile avatar
- store avatar in AuthContext
- add responsive card layout for Profile page
- allow updating avatar on backend and include it in JWT
- document required avatar images and remove binaries

## Testing
- `npm run build` *(fails: vite not found)*
- `npx -y serve -s dist` *(works but build missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859421696b88333b3db5ab56d2eb336